### PR TITLE
Python support for IDEA 2022.2+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.fapiko.jetbrains.plugins.better_direnv
 pluginName=better_direnv
 # SemVer format -> https://semver.org
-pluginVersion=0.3.0
+pluginVersion=0.3.1
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild=211

--- a/modules/products/python/src/main/java/com/fapiko/jetbrains/plugins/better_direnv/runconfigs/PycharmEnvironmentProvider.java
+++ b/modules/products/python/src/main/java/com/fapiko/jetbrains/plugins/better_direnv/runconfigs/PycharmEnvironmentProvider.java
@@ -1,0 +1,33 @@
+package com.fapiko.jetbrains.plugins.better_direnv.runconfigs;
+
+import com.fapiko.jetbrains.plugins.better_direnv.settings.DirenvSettings;
+import com.fapiko.jetbrains.plugins.better_direnv.settings.ui.RunConfigSettingsEditor;
+import com.intellij.openapi.project.Project;
+import com.jetbrains.python.run.PythonExecution;
+import com.jetbrains.python.run.PythonRunConfiguration;
+import com.jetbrains.python.run.PythonRunParams;
+import com.jetbrains.python.run.target.HelpersAwareTargetEnvironmentRequest;
+import com.jetbrains.python.run.target.PythonCommandLineTargetEnvironmentProvider;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+public class PycharmEnvironmentProvider implements PythonCommandLineTargetEnvironmentProvider {
+
+    @Override
+    public void extendTargetEnvironment(@NotNull Project project, @NotNull HelpersAwareTargetEnvironmentRequest helpersAwareTargetEnvironmentRequest, @NotNull PythonExecution pythonExecution, @NotNull PythonRunParams pythonRunParams) {
+        DirenvSettings direnvSettings = ((PythonRunConfiguration) pythonRunParams).getCopyableUserData(RunConfigSettingsEditor.USER_DATA_KEY);
+        Map<String, String> direnvVariables = RunConfigSettingsEditor.collectEnv(direnvSettings, pythonRunParams.getWorkingDirectory());
+        Map<String, String> runConfigurationVariables = pythonRunParams.getEnvs();
+
+        Stream.concat(direnvVariables.entrySet().stream(), runConfigurationVariables.entrySet().stream())
+              .forEach(addEnvironmentVariableToPythonExecution(pythonExecution));
+    }
+
+    @NotNull
+    private static Consumer<Map.Entry<String, String>> addEnvironmentVariableToPythonExecution(@NotNull PythonExecution pythonExecution) {
+        return entry -> pythonExecution.addEnvironmentVariable(entry.getKey(), entry.getValue());
+    }
+}

--- a/src/main/resources/META-INF/direnv-python.xml
+++ b/src/main/resources/META-INF/direnv-python.xml
@@ -3,5 +3,6 @@
         <runConfigurationExtension
                 implementation="com.fapiko.jetbrains.plugins.better_direnv.runconfigs.PycharmRunConfigurationExtension"
                 id="direnvPython"/>
+        <pythonCommandLineTargetEnvironmentProvider implementation="com.fapiko.jetbrains.plugins.better_direnv.runconfigs.PycharmEnvironmentProvider"/>
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Python support broken by 2022.2 - support ticket here: https://youtrack.jetbrains.com/issue/PY-56172/RunConfigurationpatchCommandLine-Not-Called-In-20222

This commit adds Python support using **experimental** APIs. This may or may not be acceptable for the plugin. Once JetBrains decides to address the issue with patchCommandLine not being called, the additional code here can likely be removed, which I'm happy to do.

Confirmed plugin is now working on 2022.1 and 2022.2+