### PR TITLE
Python support fix so PyTest and other configs extending AbstractPythonRunConfiguration work

### DIFF
--- a/modules/products/python/src/main/java/com/fapiko/jetbrains/plugins/better_direnv/runconfigs/PycharmEnvironmentProvider.java
+++ b/modules/products/python/src/main/java/com/fapiko/jetbrains/plugins/better_direnv/runconfigs/PycharmEnvironmentProvider.java
@@ -3,8 +3,8 @@ package com.fapiko.jetbrains.plugins.better_direnv.runconfigs;
 import com.fapiko.jetbrains.plugins.better_direnv.settings.DirenvSettings;
 import com.fapiko.jetbrains.plugins.better_direnv.settings.ui.RunConfigSettingsEditor;
 import com.intellij.openapi.project.Project;
+import com.jetbrains.python.run.AbstractPythonRunConfiguration;
 import com.jetbrains.python.run.PythonExecution;
-import com.jetbrains.python.run.PythonRunConfiguration;
 import com.jetbrains.python.run.PythonRunParams;
 import com.jetbrains.python.run.target.HelpersAwareTargetEnvironmentRequest;
 import com.jetbrains.python.run.target.PythonCommandLineTargetEnvironmentProvider;
@@ -18,7 +18,8 @@ public class PycharmEnvironmentProvider implements PythonCommandLineTargetEnviro
 
     @Override
     public void extendTargetEnvironment(@NotNull Project project, @NotNull HelpersAwareTargetEnvironmentRequest helpersAwareTargetEnvironmentRequest, @NotNull PythonExecution pythonExecution, @NotNull PythonRunParams pythonRunParams) {
-        DirenvSettings direnvSettings = ((PythonRunConfiguration) pythonRunParams).getCopyableUserData(RunConfigSettingsEditor.USER_DATA_KEY);
+        AbstractPythonRunConfiguration<?> runConfig = (AbstractPythonRunConfiguration<?>) pythonRunParams;
+        DirenvSettings direnvSettings = runConfig.getCopyableUserData(RunConfigSettingsEditor.USER_DATA_KEY);
         Map<String, String> direnvVariables = RunConfigSettingsEditor.collectEnv(direnvSettings, pythonRunParams.getWorkingDirectory());
         Map<String, String> runConfigurationVariables = pythonRunParams.getEnvs();
 


### PR DESCRIPTION
The cast to PythonRunConfiguration was too restrictive, so now casting to AbstractPythonRunConfiguration<?> which, as far as I can tell, all py based configs extend.

A colleague ran into issues executing PyTest with the prior implementation.