### PR TITLE
Add support for RubyMine

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -14,6 +14,7 @@
             <option value="$PROJECT_DIR$/modules/products/idea" />
             <option value="$PROJECT_DIR$/modules/products/nodejs" />
             <option value="$PROJECT_DIR$/modules/products/python" />
+            <option value="$PROJECT_DIR$/modules/products/rubymine" />
             <option value="$PROJECT_DIR$/modules/products/shellscript" />
           </set>
         </option>

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Currently supported Run Configurations:
   - NodeJS
   - Python
   - PHP
+  - Ruby
 
 Unfortunately, each run configuration type needs to be added manually. New run configuration support can be added
 by request.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation(project(":better_direnv-products-shellscript"))
     implementation(project(":better_direnv-products-python"))
     implementation(project(":better_direnv-products-phpstorm"))
+    implementation(project(":better_direnv-products-rubymine"))
 }
 
 // Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 pluginGroup=com.fapiko.jetbrains.plugins.better_direnv
 pluginName=better_direnv
 # SemVer format -> https://semver.org
-pluginVersion=1.1.0
+pluginVersion=1.2.0
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 # Issue filed in https://youtrack.jetbrains.com/issue/PY-56172/RunConfigurationpatchCommandLine-Not-Called-In-20222

--- a/modules/products/rubymine/build.gradle.kts
+++ b/modules/products/rubymine/build.gradle.kts
@@ -1,0 +1,18 @@
+fun properties(key: String) = project.findProperty(key).toString()
+
+plugins {
+    id("org.jetbrains.intellij")
+}
+
+// Configure Gradle IntelliJ Plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
+intellij {
+    version.set(properties("platformVersion"))
+    type.set("IU")
+
+    // Plugin Dependencies. Uses `platformPlugins` property from the gradle.properties file.
+    plugins.set(listOf("org.jetbrains.plugins.ruby:223.7571.4"))
+}
+
+dependencies {
+    implementation(project(":better_direnv-core"))
+}

--- a/modules/products/rubymine/src/main/java/com/fapiko/jetbrains/plugins/better_direnv/runconfigs/RubyMineRunConfigurationExtension.java
+++ b/modules/products/rubymine/src/main/java/com/fapiko/jetbrains/plugins/better_direnv/runconfigs/RubyMineRunConfigurationExtension.java
@@ -1,0 +1,59 @@
+package com.fapiko.jetbrains.plugins.better_direnv.runconfigs;
+
+import com.intellij.execution.configurations.GeneralCommandLine;
+import com.intellij.execution.configurations.RunnerSettings;
+import com.intellij.openapi.options.SettingsEditor;
+import com.fapiko.jetbrains.plugins.better_direnv.settings.DirenvSettings;
+import com.fapiko.jetbrains.plugins.better_direnv.settings.ui.RunConfigSettingsEditor;
+import org.jdom.Element;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.plugins.ruby.ruby.run.configuration.AbstractRubyRunConfiguration;
+import org.jetbrains.plugins.ruby.ruby.run.configuration.RubyRunConfigurationExtension;
+
+import java.util.Map;
+
+public class RubyMineRunConfigurationExtension extends RubyRunConfigurationExtension {
+
+    @Override
+    protected void readExternal(@NotNull AbstractRubyRunConfiguration runConfiguration, @NotNull Element element) {
+        RunConfigSettingsEditor.readExternal(runConfiguration, element);
+    }
+
+    @Override
+    protected void writeExternal(@NotNull AbstractRubyRunConfiguration runConfiguration, @NotNull Element element) {
+        RunConfigSettingsEditor.writeExternal(runConfiguration, element);
+    }
+
+    @Override
+    protected @Nullable <P extends AbstractRubyRunConfiguration<?>> SettingsEditor<P> createEditor(@NotNull P configuration) {
+        return new RunConfigSettingsEditor<>(configuration);
+    }
+
+    @Nullable
+    @Override
+    protected String getEditorTitle() {
+        return RunConfigSettingsEditor.getEditorTitle();
+    }
+
+    @Override
+    public boolean isApplicableFor(@NotNull AbstractRubyRunConfiguration<?> configuration) {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabledFor(@NotNull AbstractRubyRunConfiguration<?> applicableConfiguration, @Nullable RunnerSettings runnerSettings) {
+        return true;
+    }
+
+    @Override
+    protected void patchCommandLine(@NotNull AbstractRubyRunConfiguration configuration, @Nullable RunnerSettings runnerSettings, @NotNull GeneralCommandLine cmdLine, @NotNull String runnerId) {
+        DirenvSettings direnvSettings = configuration.getCopyableUserData(RunConfigSettingsEditor.USER_DATA_KEY);
+
+        Map<String, String> newEnv = RunConfigSettingsEditor.collectEnv(direnvSettings, configuration.getProject().getBasePath());
+
+        for (Map.Entry<String, String> set : newEnv.entrySet()) {
+            cmdLine.withEnvironment(set.getKey(), set.getValue());
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,7 +7,8 @@ include(
     "modules/products/nodejs",
     "modules/products/shellscript",
     "modules/products/python",
-    "modules/products/phpstorm"
+    "modules/products/phpstorm",
+    "modules/products/rubymine"
 )
 
 rootProject.children.forEach {

--- a/src/main/resources/META-INF/direnv-rubymine.xml
+++ b/src/main/resources/META-INF/direnv-rubymine.xml
@@ -1,0 +1,7 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="org.jetbrains.plugins.ruby">
+        <runConfigurationExtension
+                implementation="com.fapiko.jetbrains.plugins.better_direnv.runconfigs.RubyMineRunConfigurationExtension"
+                id="direnvRubyMineRunConfig"/>
+    </extensions>
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -12,4 +12,5 @@
     <depends optional="true" config-file="direnv-javascript.xml">JavaScript</depends>
     <depends optional="true" config-file="direnv-python.xml">com.intellij.modules.python</depends>
     <depends optional="true" config-file="direnv-phpstorm.xml">com.jetbrains.php</depends>
+    <depends optional="true" config-file="direnv-rubymine.xml">org.jetbrains.plugins.ruby</depends>
 </idea-plugin>


### PR DESCRIPTION
Hi! This merge request adds support for using `direnv` in RubyMine.

## This is how it looks in the `Run` configuration settings:

![image](https://github.com/Fapiko/intellij-better-direnv/assets/1894248/ccb888f0-a26c-4e28-a8a6-9bd845539196)

## This plugin in action

| When disabled  | When enabled |
| ------------- | ------------- |
| ![image](https://github.com/Fapiko/intellij-better-direnv/assets/1894248/6dab76b2-71b7-4dd5-98d5-f6367248d6ea) | ![image](https://github.com/Fapiko/intellij-better-direnv/assets/1894248/ceb5c76d-9c12-41b2-88ca-8f1409dfe984)|

`InvalidAccessToken` is an exception that happens with invalid access token. I have a valid token in my `.envrc` file.

**Tested on:**

This version is also used in plugin dependencies (platform).

```
RubyMine 2023.1.2
Build #RM-231.9011.41, built on May 17, 2023
Licensed to GitLab Inc.

Runtime version: 17.0.6+10-b829.9 aarch64
VM: OpenJDK 64-Bit Server VM by JetBrains s.r.o.
macOS 13.4
GC: G1 Young Generation, G1 Old Generation
Memory: 2048M
Cores: 10
Metal Rendering is ON
Registry:
    debugger.new.tool.window.layout=true
    ide.experimental.ui=true

Non-Bundled Plugins:
    com.fapiko.jetbrains.plugins.better_direnv (1.1.0)
```

Thanks!

