### PR TITLE
Add tab title to run configuration editor

### DIFF
--- a/modules/products/idea/src/main/java/com/fapiko/jetbrains/plugins/better_direnv/runconfigs/IdeaRunConfigurationExtension.java
+++ b/modules/products/idea/src/main/java/com/fapiko/jetbrains/plugins/better_direnv/runconfigs/IdeaRunConfigurationExtension.java
@@ -9,6 +9,7 @@ import com.intellij.execution.configurations.JavaParameters;
 import com.intellij.execution.configurations.RunConfigurationBase;
 import com.intellij.execution.configurations.RunnerSettings;
 import com.intellij.openapi.options.SettingsEditor;
+import com.intellij.openapi.util.NlsContexts;
 import org.jdom.Element;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -35,6 +36,11 @@ public class IdeaRunConfigurationExtension extends RunConfigurationExtension {
 
             params.setEnv(envVars);
         }
+    }
+
+    @Override
+    protected @Nullable @NlsContexts.TabTitle String getEditorTitle() {
+        return "Direnv";
     }
 
     @Override


### PR DESCRIPTION
Provides a tab title for the run configuration editor. Without this, the plugin does not work for run configurations which extend RunConfigurationBase but which use the old-style configuration pane with tabs.